### PR TITLE
Use tilde (~) to resolve the home directory (vagrant case)

### DIFF
--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -193,7 +193,7 @@ if ($install.IsPresent)
     InstallKubernetesBinaries -Destination  $Global:BaseDir -Source $Global:ClusterConfiguration.Kubernetes.Source
     DownloadCniBinaries -NetworkMode $Global:NetworkMode -CniPath $(GetCniPath)
 
-    if (!(Test-Path $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub))
+    if (!(Test-Path ~/.ssh/id_rsa.pub))
     {
         $res = Read-Host "Do you wish to generate a SSH Key & Add it to the Linux control-plane node [Y/n] - Default [Y]"
         if ($res -eq '' -or $res -eq 'Y'  -or $res -eq 'y')
@@ -202,7 +202,7 @@ if ($install.IsPresent)
         }
     }
 
-    $pubKey = Get-Content $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub
+    $pubKey = Get-Content ~/.ssh/id_rsa.pub
     Write-Host "Execute the below commands on the Linux control-plane node ($Global:MasterIp) to add this Windows node's public key to its authorized keys"
     
     Write-Host "touch ~/.ssh/authorized_keys"
@@ -309,6 +309,6 @@ elseif ($Reset.IsPresent)
     UninstallKubernetesBinaries -Destination  $Global:BaseDir
 
     Remove-Item $Global:BaseDir -ErrorAction SilentlyContinue
-    Remove-Item $env:HOMEDRIVE\$env:HOMEPATH\.kube -ErrorAction SilentlyContinue
+    Remove-Item ~\.kube -ErrorAction SilentlyContinue
     RemoveExternalNetwork
 }

--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -193,7 +193,7 @@ if ($install.IsPresent)
     InstallKubernetesBinaries -Destination  $Global:BaseDir -Source $Global:ClusterConfiguration.Kubernetes.Source
     DownloadCniBinaries -NetworkMode $Global:NetworkMode -CniPath $(GetCniPath)
 
-    if (!(Test-Path $Global:HomeDir/.ssh/id_rsa.pub))
+    if (!(Test-Path $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub))
     {
         $res = Read-Host "Do you wish to generate a SSH Key & Add it to the Linux control-plane node [Y/n] - Default [Y]"
         if ($res -eq '' -or $res -eq 'Y'  -or $res -eq 'y')
@@ -202,7 +202,7 @@ if ($install.IsPresent)
         }
     }
 
-    $pubKey = Get-Content $Global:HomeDir/.ssh/id_rsa.pub
+    $pubKey = Get-Content $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub
     Write-Host "Execute the below commands on the Linux control-plane node ($Global:MasterIp) to add this Windows node's public key to its authorized keys"
     
     Write-Host "touch ~/.ssh/authorized_keys"
@@ -309,6 +309,6 @@ elseif ($Reset.IsPresent)
     UninstallKubernetesBinaries -Destination  $Global:BaseDir
 
     Remove-Item $Global:BaseDir -ErrorAction SilentlyContinue
-    Remove-Item $Global:HomeDir\.kube -ErrorAction SilentlyContinue
+    Remove-Item $env:HOMEDRIVE\$env:HOMEPATH\.kube -ErrorAction SilentlyContinue
     RemoveExternalNetwork
 }

--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -193,7 +193,7 @@ if ($install.IsPresent)
     InstallKubernetesBinaries -Destination  $Global:BaseDir -Source $Global:ClusterConfiguration.Kubernetes.Source
     DownloadCniBinaries -NetworkMode $Global:NetworkMode -CniPath $(GetCniPath)
 
-    if (!(Test-Path $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub))
+    if (!(Test-Path $Global:HomeDir/.ssh/id_rsa.pub))
     {
         $res = Read-Host "Do you wish to generate a SSH Key & Add it to the Linux control-plane node [Y/n] - Default [Y]"
         if ($res -eq '' -or $res -eq 'Y'  -or $res -eq 'y')
@@ -202,7 +202,7 @@ if ($install.IsPresent)
         }
     }
 
-    $pubKey = Get-Content $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub
+    $pubKey = Get-Content $Global:HomeDir/.ssh/id_rsa.pub
     Write-Host "Execute the below commands on the Linux control-plane node ($Global:MasterIp) to add this Windows node's public key to its authorized keys"
     
     Write-Host "touch ~/.ssh/authorized_keys"
@@ -309,6 +309,6 @@ elseif ($Reset.IsPresent)
     UninstallKubernetesBinaries -Destination  $Global:BaseDir
 
     Remove-Item $Global:BaseDir -ErrorAction SilentlyContinue
-    Remove-Item $env:HOMEDRIVE\$env:HOMEPATH\.kube -ErrorAction SilentlyContinue
+    Remove-Item $Global:HomeDir\.kube -ErrorAction SilentlyContinue
     RemoveExternalNetwork
 }

--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -1,7 +1,6 @@
 $Global:BaseDir = "$env:ALLUSERSPROFILE\Kubernetes"
 $Global:GithubSDNRepository = 'Microsoft/SDN'
 $Global:GithubSDNBranch = 'master'
-$Global:HomeDir = $Global:Home
 $Global:NetworkName = "cbr0"
 $Global:NetworkMode = "l2bridge"
 $Global:DockerImageTag = "1809"
@@ -123,18 +122,6 @@ function LoadGlobals()
     else {
         throw "$Global:InterfaceName doesn't exist"
     }
-
-    if (!($Global:HomeDir))
-    {
-        if ($env:HOMEDRIVE -And $env:HOMEPATH)
-        {
-            $Global:HomeDir = Join-Path -Path $env:HOMEDRIVE -ChildPath $env:HOMEPATH
-        }
-        elseif ($env:USERPROFILE)
-        {
-            $Global:HomeDir = $env:USERPROFILE
-        }
-    }
 }
 
 function ValidateConfig()
@@ -152,11 +139,6 @@ function ValidateConfig()
     if ($Global:Cri -ne "dockerd")
     {
         throw "$Global:Cri is not yet supported"
-    }
-
-    if (!($Global:HomeDir))
-    {
-        throw "HomeDir can not be discovered"
     }
 }
 
@@ -176,9 +158,6 @@ function PrintConfig()
     Write-Host "MasterIp          : $Global:MasterIp"
     Write-Host "ManagementIp      : $Global:ManagementIp"
     Write-Host "ManagementSubnet  : $Global:ManagementSubnet"
-    Write-Host "############################################"
-    Write-Host "Environment "
-    Write-Host "HomeDir           : $Global:HomeDir"
     Write-Host "############################################"
 
     ######################################################################################################################

--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -1,6 +1,7 @@
 $Global:BaseDir = "$env:ALLUSERSPROFILE\Kubernetes"
 $Global:GithubSDNRepository = 'Microsoft/SDN'
 $Global:GithubSDNBranch = 'master'
+$Global:HomeDir = $Global:Home
 $Global:NetworkName = "cbr0"
 $Global:NetworkMode = "l2bridge"
 $Global:DockerImageTag = "1809"
@@ -122,6 +123,18 @@ function LoadGlobals()
     else {
         throw "$Global:InterfaceName doesn't exist"
     }
+
+    if (!($Global:HomeDir))
+    {
+        if ($env:HOMEDRIVE -And $env:HOMEPATH)
+        {
+            $Global:HomeDir = Join-Path -Path $env:HOMEDRIVE -ChildPath $env:HOMEPATH
+        }
+        elseif ($env:USERPROFILE)
+        {
+            $Global:HomeDir = $env:USERPROFILE
+        }
+    }
 }
 
 function ValidateConfig()
@@ -139,6 +152,11 @@ function ValidateConfig()
     if ($Global:Cri -ne "dockerd")
     {
         throw "$Global:Cri is not yet supported"
+    }
+
+    if (!($Global:HomeDir))
+    {
+        throw "HomeDir can not be discovered"
     }
 }
 
@@ -158,6 +176,9 @@ function PrintConfig()
     Write-Host "MasterIp          : $Global:MasterIp"
     Write-Host "ManagementIp      : $Global:ManagementIp"
     Write-Host "ManagementSubnet  : $Global:ManagementSubnet"
+    Write-Host "############################################"
+    Write-Host "Environment "
+    Write-Host "HomeDir           : $Global:HomeDir"
     Write-Host "############################################"
 
     ######################################################################################################################


### PR DESCRIPTION
The environment variables `$env:HOMEDRIVE` and `$env:HOMEPATH` are empty
when vagrant executes `KubeCluster.ps -install`.
It makes _SSH key_ is not found even when it is correctly provisioned.
Script asks to generate _SSH key_ but it shouldn't do it.